### PR TITLE
fwchoice switch in EasyInstall.py

### DIFF
--- a/EasyInstall.py
+++ b/EasyInstall.py
@@ -104,7 +104,7 @@ def choose_fw():
 		chip="esp32s2"
 		checkforserialport()
 		flash_esp32marauder()
-	if fwchoice==2:
+	elif fwchoice==2:
 		print("You have chosen to flash Marauder on a WiFi devboard or ESP32-S2 with SD Serial Support")
 		chip="esp32s2"
 		checkforserialport()


### PR DESCRIPTION
Fixed continuing execution after choosing to flash Marauder on a WiFi devboard or ESP32-S2 with SD Serial Support. Current behavior:

![1687277344](https://github.com/SkeletonMan03/FZEasyMarauderFlash/assets/441777/37dfa27d-bb5f-4533-8e10-a4b75f58cde8)
