### PR TITLE
Dynamic download for Marauder FW URLs: Affects checkforesp32marauder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ ESP32Marauder/
 Extra_ESP32_Bins/
 EvilPortal/
 venv
+env

--- a/EasyInstall.py
+++ b/EasyInstall.py
@@ -419,9 +419,8 @@ def checkforesp32marauder():
 		marauderapi="https://api.github.com/repos/justcallmekoko/ESP32Marauder/releases/latest"
 		response=requests.get(marauderapi)
 		jsondata=response.json()
-		assetdls=range(0,11)
-		for assetdl in assetdls:
-			marauderasset=jsondata['assets'][assetdl]['browser_download_url']
+		for assetdl in jsondata['assets']:
+			marauderasset=assetdl['browser_download_url']
 			if marauderasset.find('/'):
 				filename=(marauderasset.rsplit('/', 1)[1])
 			downloadfile=requests.get(marauderasset, allow_redirects=True)


### PR DESCRIPTION
Updated the checkforesp32marauder function to treat dictionary key "assets" as an iterable instead of relying on hardcoded range value to perform downloads.

Reason: IndexError when I tried to run script.