### PR TITLE
My Sunday OSS contribution (improvements and troubleshooting FZ Devboard's)

### DIFF
--- a/EasyInstall.py
+++ b/EasyInstall.py
@@ -144,7 +144,7 @@ def choose_fw():
 	global selectedboard
 	global fwchoice
 	global fwchoicepreselect
-	hardresetlist=[FW_MARAUDER_MINI, FW_MARAUDER_V6_WROOM, FW_AWOK_V1_3_DUOBOARD, 
+	hardresetlist=[FW_MARAUDER_FLIPPER_S2, FW_MARAUDER_MINI, FW_MARAUDER_V6_WROOM, FW_AWOK_V1_3_DUOBOARD, 
 		       FW_AWOK_V4_CHUNGUS, FW_AWOK_V5, FW_AWOK_DUAL_ORANGE, 
 		       FW_AWOK_DUAL_TOUCH_WHITE, FW_AWOK_DUAL_MINI_WHITE]
 
@@ -175,9 +175,8 @@ def choose_fw():
 		offset_three='0x10000'
 		fwbin=esp32marauderfw
 		checkforserialport(FW_MARAUDER_FLIPPER_S2)
-		eraseparams=['-p', serialport, '-b', BR, '-a', 'no-reset', 'erase-flash']
-		flashparams=['-p', serialport, '-b', BR, '-c', chip, '--before', 'default-reset', '-a', reset, 'write-flash', '--flash-mode', 'dio', '--flash-freq', '80m', '--flash-size', flashsize, offset_one, bootloader_bin, offset_two, partitions_bin, offset_three, fwbin]
-		flashtheboard(eraseparams, flashparams)
+		flashparams=['-p', serialport, '-b', BR, '-c', chip, '--before', 'default-reset', '-a', reset, 'write-flash', '-z', '--flash-mode', 'dio', '--flash-freq', '80m', '--flash-size', flashsize, offset_one, bootloader_bin, offset_two, partitions_bin, offset_three, fwbin]
+		flashtheboard(None, flashparams)
 	elif fwchoice==FW_SAVE_BLACKMAGIC:
 		print("You have chosen to save Flipper Blackmagic WiFi settings")
 		chip="esp32s2"
@@ -557,7 +556,8 @@ def prereqcheck():
 	return
 
 def flashtheboard(eraseparams, flashparams):
-	erase_esp32(eraseparams)
+	if eraseparams is not None:
+		erase_esp32(eraseparams)
 	tries=3
 	attempts=0
 	for i in range(tries):

--- a/EasyInstall.py
+++ b/EasyInstall.py
@@ -175,8 +175,9 @@ def choose_fw():
 		offset_three='0x10000'
 		fwbin=esp32marauderfw
 		checkforserialport(FW_MARAUDER_FLIPPER_S2)
+		eraseparams=['-p', serialport, '-b', BR, '-a', 'no-reset', 'erase-flash']
 		flashparams=['-p', serialport, '-b', BR, '-c', chip, '--before', 'default-reset', '-a', reset, 'write-flash', '-z', '--flash-mode', 'dio', '--flash-freq', '80m', '--flash-size', flashsize, offset_one, bootloader_bin, offset_two, partitions_bin, offset_three, fwbin]
-		flashtheboard(None, flashparams)
+		flashtheboard(eraseparams, flashparams)
 	elif fwchoice==FW_SAVE_BLACKMAGIC:
 		print("You have chosen to save Flipper Blackmagic WiFi settings")
 		chip="esp32s2"
@@ -196,7 +197,7 @@ def choose_fw():
 		partitions_bin=extraesp32bins+'/Blackmagic/partition-table.bin'
 		fwbin=extraesp32bins+'/Blackmagic/blackmagic.bin'
 		checkforserialport(FW_FLASH_BLACKMAGIC)
-		eraseparams=['-p', serialport, '-b', BR, 'erase-flash']
+		eraseparams=['-p', serialport, '-b', BR, '-a', 'no-reset', 'erase-flash']
 		if os.path.exists(extraesp32bins+"/Blackmagic/nvs.bin"):
 			offset_three='0x9000'
 			wifisettings=extraesp32bins+'/Blackmagic/nvs.bin'
@@ -308,7 +309,7 @@ def choose_fw():
 		offset_three='0x10000'
 		fwbin=esp32marauderfw
 		checkforserialport(FW_AWOK_V4_CHUNGUS)
-		eraseparams=['-p', serialport, '-b', BR, 'erase-flash']
+		eraseparams=['-p', serialport, '-b', BR, '-a', 'no-reset', 'erase-flash']
 		flashparams=['-p', serialport, '-b', BR, '-c', chip, '--before', 'default-reset', '-a', reset, 'write-flash', '--flash-mode', 'dio', '--flash-freq', '80m', '--flash-size', flashsize, offset_one, bootloader_bin, offset_two, partitions_bin, offset_three, fwbin]
 		flashtheboard(eraseparams, flashparams)
 	elif fwchoice==FW_AWOK_V5:
@@ -324,7 +325,7 @@ def choose_fw():
 		offset_three='0x10000'
 		fwbin=esp32marauderfw
 		checkforserialport(FW_AWOK_V5)
-		eraseparams=['-p', serialport, '-b', BR, 'erase-flash']
+		eraseparams=['-p', serialport, '-b', BR, '-a', 'no-reset', 'erase-flash']
 		flashparams=['-p', serialport, '-b', BR, '-c', chip, '--before', 'default-reset', '-a', reset, 'write-flash', '--flash-mode', 'dio', '--flash-freq', '80m', '--flash-size', flashsize, offset_one, bootloader_bin, offset_two, partitions_bin, offset_three, fwbin]
 		flashtheboard(eraseparams, flashparams)
 	elif fwchoice==FW_AWOK_DUAL_ORANGE:
@@ -340,7 +341,7 @@ def choose_fw():
 		offset_three='0x10000'
 		fwbin=esp32marauderfw
 		checkforserialport(FW_AWOK_DUAL_ORANGE)
-		eraseparams=['-p', serialport, '-b', BR, 'erase-flash']
+		eraseparams=['-p', serialport, '-b', BR, '-a', 'no-reset', 'erase-flash']
 		flashparams=['-p', serialport, '-b', BR, '-c', chip, '--before', 'default-reset', '-a', reset, 'write-flash', '--flash-mode', 'dio', '--flash-freq', '80m', '--flash-size', flashsize, offset_one, bootloader_bin, offset_two, partitions_bin, offset_three, fwbin]
 		flashtheboard(eraseparams, flashparams)
 	elif fwchoice==FW_AWOK_DUAL_TOUCH_WHITE: 
@@ -426,6 +427,16 @@ def erase_esp32(eraseparams):
 			attempts+=1
 			print("Erasing firmware...")
 			esptool.main(eraseparams)
+		except SystemExit as e:
+			if e.code != 0:
+				print(f"Esptool error: {e}")
+				if attempts==3:
+					print("Unable to erase the firmware")
+					exit()
+				print("Waiting 5 seconds and trying again...")
+				time.sleep(5)
+				continue
+			# Exit code 0 means success, continue normally
 		except Exception as err:
 			print(err)
 			if attempts==3:
@@ -565,6 +576,16 @@ def flashtheboard(eraseparams, flashparams):
 			attempts+=1
 			print("Flashing", selectedfw, "on", selectedboard)
 			esptool.main(flashparams)
+		except SystemExit as e:
+			if e.code != 0:
+				print(f"Esptool error: {e}")
+				if attempts==3:
+					print("Could not flash", selectedfw, "on", selectedboard)
+					exit()
+				print("Waiting 5 seconds and trying again...")
+				time.sleep(5)
+				continue
+			# Exit code 0 means success, continue normally
 		except Exception as err:
 			print(err)
 			if attempts==3:
@@ -585,6 +606,16 @@ def save_flipperbmsettings(savebmset):
 			attempts +=1
 			print("Saving Flipper Blackmagic WiFi Settings to Extra_ESP32_Bins/Blackmagic/nvs.bin")
 			esptool.main(savebmset)
+		except SystemExit as e:
+			if e.code != 0:
+				print(f"Esptool error: {e}")
+				if attempts==3:
+					print("Could not save Flipper Blackmagic WiFi Settings")
+					exit()
+				print("Waiting 5 seconds and trying again...")
+				time.sleep(5)
+				continue
+			# Exit code 0 means success, continue normally
 		except Exception as err:
 			print(err)
 			if attempts==3:

--- a/README.md
+++ b/README.md
@@ -12,17 +12,28 @@ You have one prerequisite.
 You need to install `git` however you would on your system if you haven't already.  
 
 ## It is now simple to install or update Marauder or Evil Portal on Linux, Mac OS X, or Windows.
-# How to use: 
-* Ideally use a venv as it's best practice with any Python scripts, although it isn't required (Google it if you don't know what that is)
-* Step 0 only has to be ran once. (That doesn't mean it's okay to skip it unless you're running it again after having just used it)
-* Steps 1-4 are not necessary on AWOK boards
-0) run `pip3 install -r requirements.txt`. 
+
+# How to use:
+
+## Hardware Setup (for non-AWOK boards):
 1) Press and hold the `BOOT` button on the module
 2) While still holding `BOOT`, connect the devboard or ESP32 board via USB.
 3) Press and release the `RESET` button.
 4) Release the `BOOT` button. 
-5) run `python3 EasyInstall.py`. 
-6) Select the option of what you want to do
+
+## Software Setup:
+
+**Recommended:** Use [uv](https://docs.astral.sh/uv/) - it's faster, handles dependencies automatically, and manages virtual environments for you:
+```bash
+uv run python EasyInstall.py
+```
+
+**If you prefer pip:** Manual setup with traditional tools:
+* Ideally use a venv as it's best practice with any Python scripts, although it isn't required (Google it if you don't know what that is)
+* Step 0 only has to be ran once. (That doesn't mean it's okay to skip it unless you're running it again after having just used it)
+0) run `pip3 install -r requirements.txt`. 
+1) run `python3 EasyInstall.py`. 
+2) Select the option of what you want to do
 
 ## This project was based on the Windows Marauder flasher batch script
 
@@ -76,6 +87,17 @@ Here are some steps to try:
 * If you're using Windows, don't use Git Bash, it doesn't work well with this script. Instead, use Powershell, Windows Terminal, or CMD
 * On Windows and Python is acting strange? Uninstall it then re-install it via the Microsoft Store.
 * Make sure you're running the latest Python release! If you're on 3.8 when current is 3.11.3 for example, don't bother opening an issue until after you upgrade and try again. Don't try to use old stuff.
+
+## Manual Flashing Fallback
+If the script fails or doesn't work properly, you can flash manually using esptool directly. 
+
+For ESP32-S2/WiFi Devboard (Option 1), use:
+```bash
+uvx esptool --chip esp32s2 --port /dev/ttyACM0 --baud 115200 --before default-reset --after hard-reset write-flash -z --flash-mode dio --flash-freq 80m --flash-size 4MB 0x1000 Extra_ESP32_Bins/Marauder/bootloader.bin 0x8000 Extra_ESP32_Bins/Marauder/partitions.bin 0x10000 ESP32Marauder/releases/esp32_marauder_v*_flipper.bin
+```
+
+Replace `/dev/ttyACM0` with your actual serial port and adjust the firmware path as needed. The script now shows boot mode instructions automatically for ESP32-S2 devices when they're not detected.
+
 * Still can't get it and don't understand CLI at all and can't even figure out how to cd? What are you even doing? This definitely isn't for you. Try using the ESP Flasher app on your Flipper Zero.  
 
 ## Why do I kind of pick on Windows users?

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Here are some steps to try:
 ## Manual Flashing Fallback
 If the script fails or doesn't work properly, you can flash manually using esptool directly. 
 
-For ESP32-S2/WiFi Devboard (Option 1), use:
+Here's an example using `uvx` for ESP32-S2/WiFi Devboard (Option 1):
 ```bash
 uvx esptool --chip esp32s2 --port /dev/ttyACM0 --baud 115200 --before default-reset --after hard-reset write-flash -z --flash-mode dio --flash-freq 80m --flash-size 4MB 0x1000 Extra_ESP32_Bins/Marauder/bootloader.bin 0x8000 Extra_ESP32_Bins/Marauder/partitions.bin 0x10000 ESP32Marauder/releases/esp32_marauder_v*_flipper.bin
 ```


### PR DESCRIPTION
Hi there! So, I started today wanting to add a simple boot mode reminder for ESP32-S2 devices when they're not detected during flashing. Just wanted it for option 1, and then I realized I did not feel comfortable just hardcoding a '1'. So I ended up 'refactoring' the whole thing to use named constants like `FW_MARAUDER_FLIPPER_S2` instead of magic numbers like `1`.

Now it's easier to read tbh 😅 . I added what I initially wanted to add, and now the boot mode instructions show up for all ESP32-S2 based devices, not just option `1`.

While I was at it, my python linters where screaming about some unbound variables like `device` and `filename`, and then a bare `except:` clause. I fixed them too. Though mostly, they were going to be triggered if you had networking errors or a corrupt state of the repo (as it is right now, idk in the future might be triggered by something else).

But then I hit this annoying bug where option `1` would erase successfully but never actually flash the firmware. The script would just... stop. After some back and forth debugging, and flashing correctly manually, I figured out the issue was that `esptool.main()` calls `sys.exit()` internally when you use the `--after` parameter, which kills the entire Python process 👀 .

 So what I did was, copy the behaviour from my successfull command, which didn't do a separate erase step at all - just went straight to `write-flash` with the `-z` flag, and `write-flash` handles erasing automatically.

 I think MAYBE witching to `subprocess` to avoid the `sys.exit` issue would be the best in the future, I don't know how this might be affecting other options. In this case, we skip the erase step entirely for option `1` by passing `None` as the erase parameters since it is not needed.

Is it the best solution? For a script probably yes, but if this scales I'd do something different :)

The "right" way would be to fix the underlying `esptool.main() sys.exit()` problem (or at least what I understood it was), but that's a bigger change that could break other things and my Sunday is almost over!

And btw, now my Flipper Zero's dev-board flashes like a charm. I felt like I wanted to contribute back to this because I liked its simplicity and I don't always remember stuff like "holding down buttons in a simple pattern" to make things work hah.

Cheers!