### PR TITLE
Fix package names and remove argparse from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
-gitpython
-glob2
+GitPython
 pyserial
 requests
 esptool
 colorama
-argparse


### PR DESCRIPTION
Updated package names to match correct casing and removed argparse.